### PR TITLE
Fix electron side bugs

### DIFF
--- a/src/pages/settings-page.tsx
+++ b/src/pages/settings-page.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 // Theme toggle removed - always dark theme
 import { AuthService } from '@/services/auth-service';
 import { PythonBridge, AppPreferences } from '@/services/python-bridge';
-import { X, ArrowLeft, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 
 interface SettingsPageProps {
   onClose: () => void;
@@ -278,7 +278,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
       {/* Footer */}
       <div className="flex items-center justify-between mt-6 pt-4 border-t border-[#2a2d35]">
         <div className="text-gray-500 text-sm select-none">
-          Open World Labs © 2025
+          Open World Labs © {new Date().getFullYear()}
         </div>
         
         <button

--- a/src/pages/widget-ui.tsx
+++ b/src/pages/widget-ui.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, Video, Play, Square } from 'lucide-react';
+import { Settings, Play, Square } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { AuthService } from '@/services/auth-service';
 import { PythonBridge } from '@/services/python-bridge';
 
 interface WidgetUIProps {

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -28,7 +28,9 @@ export class AuthService {
       const result = await ElectronService.loadCredentials();
       if (result.success && result.data.apiKey) {
         this.apiKey = result.data.apiKey;
-        this.hasConsented = result.data.hasConsented || false;
+        // Convert stored consent value to a strict boolean
+        const consentVal = result.data.hasConsented;
+        this.hasConsented = consentVal === true || consentVal === 'true';
       } else {
         // Try to load from localStorage as fallback
         const storedKey = localStorage.getItem('apiKey');


### PR DESCRIPTION
## Summary
- sanitize consent value when loading credentials
- remove unused imports in widget UI
- show dynamic year in settings footer

## Testing
- `npm run build`
