### PR TITLE
Fix dark theme artifacts on auth screens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,22 @@ const App = () => {
         background-color: #0c0c0f !important;
         color: #f8f9fa !important;
       }
+
+      /* Fix black boxes around text on auth screens */
+      h1, h2, h3, h4, h5, h6, p, span, label, a,
+      div.text-sm, div.text-muted-foreground, div.flex.items-center {
+        background-color: transparent !important;
+      }
+
+      [class*="card-header"], [class*="card-title"], [class*="card-description"],
+      .text-sm, .text-muted-foreground, .col-span-2, .flex.items-center,
+      p.text-sm, div.text-sm, .space-y-2, .space-y-4 {
+        background-color: transparent !important;
+      }
+
+      .col-span-2 *, div.flex.items-center *, .rounded-lg.border.p-4 * {
+        background-color: transparent !important;
+      }
       
       /* Aurora background effect */
       body::before {

--- a/src/settings-styles.css
+++ b/src/settings-styles.css
@@ -6,7 +6,7 @@
 }
 
 /* Force dark mode on all elements including dynamically created ones */
-html, body, #root, div, section, article, aside, main, header, footer, nav {
+html, body, #root, section, article, aside, main, header, footer, nav {
   background-color: #0c0c0f !important;
   color: #f8f9fa !important;
 }
@@ -95,7 +95,7 @@ div.flex.min-h-screen.flex-col.items-center.justify-center {
 
 /* Prevent any white backgrounds on resize */
 @media (min-width: 640px), (min-width: 768px), (min-width: 1024px), (min-width: 1280px) {
-  html, body, #root, div, section, article, main {
+  html, body, #root, section, article, main {
     background-color: #0c0c0f !important;
   }
   div[class*="card"], div[class*="bg-card"], .card {


### PR DESCRIPTION
## Summary
- remove dark backgrounds from auth text containers
- keep API key and consent pages artifact-free

## Testing
- `npm run build`
