### PR TITLE
Implement presigned upload support

### DIFF
--- a/vg_control/data/uploader.py
+++ b/vg_control/data/uploader.py
@@ -1,0 +1,60 @@
+import os
+from typing import List, Optional
+
+import requests
+
+from ..constants import API_BASE_URL
+
+
+def get_upload_url(
+    api_key: str,
+    archive_path: str,
+    video_filename: str,
+    control_filename: str,
+    tags: Optional[List[str]] = None,
+    base_url: str = API_BASE_URL,
+) -> str:
+    """Request a pre-signed S3 URL for uploading a tar archive."""
+
+    file_size_mb = os.path.getsize(archive_path) // (1024 * 1024)
+    payload = {
+        "filename": os.path.basename(archive_path),
+        "content_type": "application/x-tar",
+        "file_size_mb": file_size_mb,
+        "expiration": 3600,
+        "video_filename": os.path.basename(video_filename),
+        "control_filename": os.path.basename(control_filename),
+    }
+    if tags:
+        payload["tags"] = tags
+
+    headers = {"Content-Type": "application/json", "X-API-Key": api_key}
+    url = f"{base_url}/tracker/upload/game_control"
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("url") or data.get("upload_url") or data["uploadUrl"]
+
+
+def upload_archive(
+    api_key: str,
+    archive_path: str,
+    video_filename: str,
+    control_filename: str,
+    tags: Optional[List[str]] = None,
+    base_url: str = API_BASE_URL,
+) -> None:
+    """Upload an archive to the storage bucket via a pre-signed URL."""
+
+    upload_url = get_upload_url(
+        api_key,
+        archive_path,
+        video_filename,
+        control_filename,
+        tags=tags,
+        base_url=base_url,
+    )
+
+    with open(archive_path, "rb") as f:
+        put_resp = requests.put(upload_url, data=f, timeout=60)
+        put_resp.raise_for_status()

--- a/vg_control/upload_worker.py
+++ b/vg_control/upload_worker.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+import tarfile
+import tempfile
+import uuid
+from typing import List, Tuple
+
+from .constants import ROOT_DIR
+from .data.uploader import upload_archive
+
+
+def find_unuploaded_sessions(root_dir: str = ROOT_DIR) -> List[Tuple[str, str, str]]:
+    """Return a list of (directory, video_file, csv_file) tuples for sessions that have not been uploaded."""
+    sessions = []
+    for root, _, files in os.walk(root_dir):
+        if ".uploaded" in files:
+            continue
+        mp4s = [f for f in files if f.lower().endswith(".mp4")]
+        csvs = [f for f in files if f.lower().endswith(".csv")]
+        if mp4s and csvs:
+            sessions.append((root, mp4s[0], csvs[0]))
+    return sessions
+
+
+def create_tar(directory: str, video_file: str, csv_file: str) -> str:
+    """Create a temporary tar archive containing the video and csv."""
+    tmp_dir = tempfile.gettempdir()
+    tar_path = os.path.join(tmp_dir, f"{uuid.uuid4().hex[:16]}.tar")
+    with tarfile.open(tar_path, "w") as tar:
+        tar.add(os.path.join(directory, video_file), arcname=video_file)
+        tar.add(os.path.join(directory, csv_file), arcname=csv_file)
+    return tar_path
+
+
+def mark_uploaded(directory: str) -> None:
+    """Create a .uploaded file in the session directory."""
+    flag_path = os.path.join(directory, ".uploaded")
+    with open(flag_path, "w"):
+        pass
+
+
+async def process_session(api_key: str, directory: str, video_file: str, csv_file: str) -> None:
+    """Compress and upload a single session."""
+    tar_path = create_tar(directory, video_file, csv_file)
+    try:
+        upload_archive(
+            api_key,
+            tar_path,
+            video_file,
+            csv_file,
+        )
+        mark_uploaded(directory)
+    finally:
+        if os.path.exists(tar_path):
+            os.remove(tar_path)
+        await asyncio.sleep(1)
+
+
+async def process_all_sessions(api_key: str, root_dir: str = ROOT_DIR) -> None:
+    """Find and upload all unuploaded sessions once."""
+    sessions = find_unuploaded_sessions(root_dir)
+    for directory, video_file, csv_file in sessions:
+        try:
+            await process_session(api_key, directory, video_file, csv_file)
+        except Exception as exc:
+            print(f"Failed to upload {directory}: {exc}")
+
+
+async def upload_worker(api_key: str, root_dir: str = ROOT_DIR, check_interval: int = 300) -> None:
+    """Background task that periodically uploads any new sessions."""
+    while True:
+        await process_all_sessions(api_key, root_dir)
+        await asyncio.sleep(check_interval)


### PR DESCRIPTION
## Summary
- add utility to request signed upload url and upload archive via requests
- add background async worker for periodic uploads

## Testing
- `black vg_control/upload_worker.py vg_control/data/uploader.py`
- `flake8 vg_control/data/uploader.py vg_control/upload_worker.py` *(fails: command not found)*
- `mypy vg_control/data/uploader.py vg_control/upload_worker.py` *(fails: missing imports)*
- `pytest -q` *(fails: command not found)*