### PR TITLE
Recording fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## 🎮 What is OWL Control?
 
-OWL Control automatically records your gameplay sessions (video + keyboard/mouse inputs) from supported single-player games using OBS websocket. This data is uploaded to create a public dataset that researchers worldwide can use to train AI models.
+OWL Control records your gameplay sessions (video + keyboard/mouse inputs) from single-player games, using OBS to do the recording work. This data is uploaded to create a public dataset that researchers worldwide can use to train AI models.
 
 ## 🚀 Getting Started (User Installation)
 
@@ -49,16 +49,16 @@ OWL Control automatically records your gameplay sessions (video + keyboard/mouse
 </tr>
 <tr>
 <td align="center">7️⃣</td>
-<td><strong>Start gaming!</strong> OWL Control will automatically record supported games</td>
+<td><strong>Start gaming!</strong> Recordings are currently manually initiated; when in any fullscreen game, hit F4 to start recording, and F5 to stop (by default)</td>
 </tr>
 </table>
 
 ## 🛡️ Risks And Additional Information
 
-Audio: OWL control does not record microphone inputs. It does record all system audio. Be aware of this if on voice chat/watching videos in the background during your play session.  
-Accidental Recording: We have observed a bug where sometimes OWL control responds to F4 (the default record button, which can be accidentally activated if one alt-f4s a game to close it) right after you close a game. In cases where this happens, it can be a good idea to quickly double check OBS after you close a game. Black recordings that result from this will be filtered out of the uploaded dataset but might still upload.  
-Processing: All data will undergo an automated vetting process to ensure we aren't using any empty recordings. That being said, OWL Control specifically sets OBS to record full screen applications, so there is no risk of accidental desktop capture.  
-Data Verification: You can press "file -> show recordings" in OBS if you want to verify your data is recording properly before upload.  
+- **Audio**: OWL control does not record microphone inputs. It does record all system audio. Be aware of this if on voice chat/watching videos in the background during your play session.  
+- **Accidental Recording**: We have observed a bug where sometimes OWL control responds to F4 (the default record button, which can be accidentally activated if one alt-f4s a game to close it) right after you close a game. In cases where this happens, it can be a good idea to quickly double check OBS after you close a game. Black recordings that result from this will be filtered out of the uploaded dataset but might still upload.  
+- **Processing**: All data will undergo an automated vetting process to ensure we aren't using any empty recordings. That being said, OWL Control specifically sets OBS to record full screen applications, so there is no risk of accidental desktop capture.  
+- **Data Verification**: You can press "file -> show recordings" in OBS if you want to verify your data is recording properly before upload.  
 
 ## 💻 System Requirements
 

--- a/crates/video-audio-recorder/src/lib.rs
+++ b/crates/video-audio-recorder/src/lib.rs
@@ -165,6 +165,13 @@ impl WindowRecorder {
             return Err(eyre!("No start response received from OBS bridge"));
         }
 
+        // Once we're done reading stdout, spin up a task to echo stdout
+        tokio::spawn(async move {
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!("OBS bridge stdout: {}", line);
+            }
+        });
+
         tracing::debug!("OBS recording started successfully");
         Ok(recorder)
     }

--- a/vg_control/video/obs_client.py
+++ b/vg_control/video/obs_client.py
@@ -146,14 +146,14 @@ class OBSClient:
             if item['sourceName'] == 'owl_game_capture':
                 owl_gc_id = item['sceneItemId']
                 break
+        # in a classic pro gamer move, the structure of this transform is not documented
+        # outside of the code: <https://github.com/obsproject/obs-websocket/blob/40d26dbf4d29137bf88cd393a3031adb04d68bba/src/requesthandler/RequestHandler_SceneItems.cpp#L399-L440>
         new_tform_dict = {
-            'position' : {
-                'x' : 0.0, 'y' : 0.0
-            },
-            'rotation' : 0.0,
-            'scale' : {
-                'x' : 1.0, 'y' : 1.0
-            }
+            'positionX': 0.0,
+            'positionY': 0.0,
+            'scaleX': 1.0,
+            'scaleY': 1.0,
+            'rotation': 0.0,
         }
         self.req_client.set_scene_item_transform("owl_data_collection_scene", owl_gc_id, new_tform_dict)
         

--- a/vg_control/video/obs_client.py
+++ b/vg_control/video/obs_client.py
@@ -118,7 +118,7 @@ class OBSClient:
         
         # Verify the path was set correctly
         try:
-            current_path = self.req_client.get_profile_parameter("SimpleOutput", "FilePath")
+            current_path = self.req_client.get_profile_parameter("SimpleOutput", "FilePath").parameter_value
             print(f"OBS confirmed recording path: {current_path}", file=sys.stderr)
         except Exception as e:
             print(f"Warning: Could not verify recording path: {e}", file=sys.stderr)

--- a/vg_control/video/obs_client.py
+++ b/vg_control/video/obs_client.py
@@ -68,36 +68,6 @@ class OBSClient:
 
         self.event_client.callback.register(on_record_state_changed)
         
-        # Convert forward slashes to backslashes for Windows
-        # Write recording path to debug log
-        recording_path = recording_path.replace("\\\\?\\", "")
-        self.req_client.set_profile_parameter("SimpleOutput", "FilePath", recording_path)
-        
-        # Give OBS a moment to process the path change
-        time.sleep(0.5)
-        
-        # Verify the path was set correctly
-        try:
-            current_path = self.req_client.get_profile_parameter("SimpleOutput", "FilePath")
-            print(f"OBS confirmed recording path: {current_path}", file=sys.stderr)
-        except Exception as e:
-            print(f"Warning: Could not verify recording path: {e}", file=sys.stderr)
-
-        # Monitor/resolution info
-        ml = self.req_client.get_monitor_list().monitors
-        #primary_monitor = next(m for m in ml if m['monitorIndex'] == 0)
-        #monitor_height = primary_monitor['monitorHeight']
-        #monitor_width = primary_monitor['monitorWidth']
-        monitor_width, monitor_height = get_primary_monitor_resolution()
-        
-        self.req_client.set_video_settings(
-            FPS,
-            1,
-            monitor_width,
-            monitor_height,
-            RECORDING_WIDTH,
-            RECORDING_HEIGHT,
-        )
 
         profile_list = self.req_client.get_profile_list()
         crnt_profile = profile_list.current_profile_name
@@ -131,6 +101,44 @@ class OBSClient:
         self.req_client.set_input_volume('Mic/Aux', None, -100)
         self.req_client.set_input_volume('Desktop Audio', None, 0)
 
+        # Init the profile, make sure all params are right
+        self.req_client.set_current_profile('owl_data_recorder')
+        self.req_client.set_profile_parameter("SimpleOutput", "RecQuality", "Stream")
+        self.req_client.set_profile_parameter("SimpleOutput", "VBitrate", str(VIDEO_BITRATE))
+        self.req_client.set_profile_parameter("Output", "Mode", "Simple")
+        self.req_client.set_profile_parameter("SimpleOutput", "RecFormat2", "mp4")
+
+        # Convert forward slashes to backslashes for Windows
+        # Write recording path to debug log
+        recording_path = recording_path.replace("\\\\?\\", "")
+        self.req_client.set_profile_parameter("SimpleOutput", "FilePath", recording_path)
+        
+        # Give OBS a moment to process the path change
+        time.sleep(0.5)
+        
+        # Verify the path was set correctly
+        try:
+            current_path = self.req_client.get_profile_parameter("SimpleOutput", "FilePath")
+            print(f"OBS confirmed recording path: {current_path}", file=sys.stderr)
+        except Exception as e:
+            print(f"Warning: Could not verify recording path: {e}", file=sys.stderr)
+
+        # Monitor/resolution info
+        ml = self.req_client.get_monitor_list().monitors
+        #primary_monitor = next(m for m in ml if m['monitorIndex'] == 0)
+        #monitor_height = primary_monitor['monitorHeight']
+        #monitor_width = primary_monitor['monitorWidth']
+        monitor_width, monitor_height = get_primary_monitor_resolution()
+        
+        self.req_client.set_video_settings(
+            FPS,
+            1,
+            monitor_width,
+            monitor_height,
+            RECORDING_WIDTH,
+            RECORDING_HEIGHT,
+        )
+        
         # Find the owl game capture scene id
         item_list = self.req_client.get_scene_item_list("owl_data_collection_scene").scene_items
         owl_gc_id = None
@@ -148,13 +156,6 @@ class OBSClient:
             }
         }
         self.req_client.set_scene_item_transform("owl_data_collection_scene", owl_gc_id, new_tform_dict)
-
-        # Init the profile, make sure all params are right
-        self.req_client.set_current_profile('owl_data_recorder')
-        self.req_client.set_profile_parameter("SimpleOutput", "RecQuality", "Stream")
-        self.req_client.set_profile_parameter("SimpleOutput", "VBitrate", str(VIDEO_BITRATE))
-        self.req_client.set_profile_parameter("Output", "Mode", "Simple")
-        self.req_client.set_profile_parameter("SimpleOutput", "RecFormat2", "mp4")
         
         # Conditional encoder settings - only override if SET_ENCODER is True
         if SET_ENCODER:


### PR DESCRIPTION
Various fixes and improvements:
- Removes all mention of automated recording in the README
- Moves profile updates to after profile creation, ensuring that output folder / resolution / etc. are set correctly
- Keeps bridge stdout alive, so that the bridge won't error on trying to write to a closed stdout
- Prints the actual path of the recording in obsclient

Notes:
- I've left "In OBS, go to File -> Settings -> Output -> Streaming and set encoder to NVENC with p7 (highest quality) preset" alone in the README, but there's not really a clean way for the user to do this. The profile is only created upon first recording, which means they have to start a recording, stop it, update the settings, and hope that OWLC won't reset it again (e.g. if `SET_ENCODING` is turned on)
  - This could be fixed by spinning up the OBS client when OWLC is launched and having it create the profile ahead of time, so that the user can change settings before they start recording, but as OWLC is free to adjust the profile, that setting could be implicitly reset. I'd suggest letting the user pick which encoder to use from OWLC.
- My 43:18 (1440p ultrawide) recording is output at 16:9, which results in a squished image. I'm not sure if this is intentional.
- please format your code :sob: