### PR TITLE
fix(uploader): bypass SSL checking

### DIFF
--- a/vg_control/data/uploader.py
+++ b/vg_control/data/uploader.py
@@ -159,7 +159,7 @@ def upload_archive(
             print(f"PROGRESS: {json.dumps(progress_data)}")
     
     # Use -# for a simpler progress indicator that's easier to parse
-    curl_command = f'curl -X PUT "{upload_url}" -H "Content-Type: application/x-tar" -T "{archive_path}" -# -m 1200'
+    curl_command = f'curl -X PUT "{upload_url}" -k -H "Content-Type: application/x-tar" -T "{archive_path}" -# -m 1200'
     
     # Debug: log the upload URL (hide sensitive parts)
     from urllib.parse import urlparse


### PR DESCRIPTION
Curl is returning a SSL error, interrupting some connections:
```
  Traceback (most recent call last):
    File "C:\Users\Public\owl-control\vg_control\upload_bridge.py", line 22, in main
      upload_all_files(token, delete_uploaded=del_uploaded, progress_mode=progress_mode)
    File "C:\Users\Public\owl-control\vg_control\data\owl.py", line 332, in upload_all_files
      manager.upload()
    File "C:\Users\Public\owl-control\vg_control\data\owl.py", line 288, in upload
      upload_archive(self.token, tar_name, progress_mode=self.progress_mode)
    File "C:\Users\Public\owl-control\vg_control\data\uploader.py", line 244, in upload_archive
      raise Exception(f"Upload failed with return code {return_code}")
  Exception: Upload failed with return code 35
```

From the `man` page:
```
  35     SSL connect error. The SSL handshaking failed.
```

We are bypassing SSL checking on line 58 already, so let's mirror that for a quick fix.

A more robust solution could be a simple retry loop, supplying an appropriate ca cert for OWL within the uploader client, or use the Tigris client directly.