### PR TITLE
Install `uv` Python in OWL Control resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owl-recorder"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/src/main.ts
+++ b/src/main.ts
@@ -655,6 +655,10 @@ function rootDir() {
   }
 }
 
+/**
+ * Spawns uv with the same behavior as spawn_uv() in crates/video-audio-recorder/src/lib.rs.
+ * These functions should be kept synchronized.
+ */
 function spawnUv(args: string[], options?: SpawnOptionsWithoutStdio) {
   const isDevelopment = process.env.NODE_ENV === 'development';
   // Use system uv in development, bundled uv in production
@@ -673,9 +677,9 @@ function spawnUv(args: string[], options?: SpawnOptionsWithoutStdio) {
     if (!fs.existsSync(uvDir)) {
       fs.mkdirSync(uvDir, { recursive: true });
     }
-    
-    env = { 
-      ...env,  
+
+    env = {
+      ...env,
       // Always copy deps, do not hardlink
       UV_LINK_MODE: 'copy',
       // Do not let the user's configuration interfere with our uv
@@ -694,8 +698,8 @@ function spawnUv(args: string[], options?: SpawnOptionsWithoutStdio) {
   }
 
   return spawn(uvPath, args, {
-    ...(options || {}), 
-    env, 
+    ...(options || {}),
+    env,
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Tray, Menu, nativeImage, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
-import { spawn } from 'child_process';
+import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { join } from 'path';
 import * as os from 'os';
 
@@ -473,7 +473,7 @@ async function ensurePythonDependencies() {
       logToFile('STARTUP: Creating Python virtual environment and installing dependencies');
       
       // First create virtual environment, then install dependencies
-      const venvProcess = spawn(getUvPath(), [
+      const venvProcess = spawnUv([
         'venv',
         '--python', '3.12'
       ], {
@@ -498,10 +498,7 @@ async function ensurePythonDependencies() {
           logToFile('STARTUP: Virtual environment created, installing dependencies');
           
           // Now install dependencies into the virtual environment
-          const installProcess = spawn(getUvPath(), [
-            'sync',
-            '--frozen'  // Use lockfile without updating it
-          ], {
+          const installProcess = spawnUv(['sync'], {
             cwd: rootDir(),
           });
 
@@ -619,7 +616,7 @@ function startUploadBridge(apiToken: string, deleteUploadedFiles: boolean) {
   try {
     console.log(`Starting upload bridge module from vg_control package`);
 
-    const uploadProcess = spawn(getUvPath(), [
+    const uploadProcess = spawnUv([
       'run',
       '-m',
       'vg_control.upload_bridge',
@@ -658,13 +655,48 @@ function rootDir() {
   }
 }
 
-function getUvPath() {
-  if (process.env.NODE_ENV === 'development') {
-    return 'uv'; // Use system uv in development
-  } else {
-    // Use bundled uv in production
-    return path.join(process.resourcesPath, 'uv.exe');
+function spawnUv(args: string[], options?: SpawnOptionsWithoutStdio) {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  // Use system uv in development, bundled uv in production
+  const uvPath = isDevelopment ? 'uv' : path.join(process.resourcesPath, 'uv.exe');
+  let env: Record<string, string> = {
+    ...(options?.env || {}),
+    // Do not attempt to update the dependencies
+    'UV_FROZEN': '1',
+  };
+
+  if (!isDevelopment) {
+    // In production, we override all of uv's paths to ensure that it installs everything locally
+    // to OWLC, which should stop it from interfering with the user's global state and/or
+    // have a better chance of working in non-standard configurations
+    const uvDir = path.join(process.resourcesPath, 'uv');
+    if (!fs.existsSync(uvDir)) {
+      fs.mkdirSync(uvDir, { recursive: true });
+    }
+    
+    env = { 
+      ...env,  
+      // Always copy deps, do not hardlink
+      UV_LINK_MODE: 'copy',
+      // Do not let the user's configuration interfere with our uv
+      UV_NO_CONFIG: '1',
+      // Mark all dependencies as non-editable
+      UV_NO_EDITABLE: '1',
+      // Ensure we always use our managed Python
+      UV_MANAGED_PYTHON: '1',
+      // Update all directories
+      UV_CACHE_DIR: path.join(uvDir, 'cache'),
+      UV_PYTHON_INSTALL_DIR: path.join(uvDir, 'python_install'),
+      UV_PYTHON_BIN_DIR: path.join(uvDir, 'python_bin'),
+      UV_TOOL_DIR: path.join(uvDir, 'tool'),
+      UV_TOOL_BIN_DIR: path.join(uvDir, 'tool_bin'),
+    };
   }
+
+  return spawn(uvPath, args, {
+    ...(options || {}), 
+    env, 
+  });
 }
 
 // App ready event
@@ -895,7 +927,7 @@ function setupIpcHandlers() {
     try {
       console.log('Starting upload with progress tracking');
       
-      const uploadProcess = spawn(getUvPath(), [
+      const uploadProcess = spawnUv([
         'run',
         '-m',
         'vg_control.upload_bridge',


### PR DESCRIPTION
Theoretically fixes issues with `uv` not being able to spawn system-located Python installs by forcing it to install its own Python within the resources path.

Tested locally, but I'm going to test it in a VM just to make sure it behaves as expected on a stock Windows 11.

I considered using [PyInstaller](https://pyinstaller.org/en/stable/) or [PyApp](https://ofek.dev/pyapp/latest/), but both seemed like they would require more engineering effort than would be desirable for something that we're hopefully going to rip out in the near-future, especially with @Clyde013's work.