### PR TITLE
Increase Idle Timeout

### DIFF
--- a/crates/owl-recorder/src/main.rs
+++ b/crates/owl-recorder/src/main.rs
@@ -42,7 +42,7 @@ struct Args {
     stop_key: String,
 }
 
-const MAX_IDLE_DURATION: Duration = Duration::from_secs(30);
+const MAX_IDLE_DURATION: Duration = Duration::from_secs(90);
 const MAX_RECORDING_DURATION: Duration = Duration::from_secs(10 * 60);
 
 #[tokio::main]
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
                         recorder.stop().await?;
                     } else if idleness_tracker.is_idle() {
                         tracing::info!("No input detected for 5 seconds, stopping recording");
-                        recorder.stop().await?;
+                        recorder.stop().await?; 
                         start_on_activity = true;
                     } else if recording.elapsed() > MAX_RECORDING_DURATION {
                         tracing::info!("Recording duration exceeded {} s, restarting recording", MAX_RECORDING_DURATION.as_secs());


### PR DESCRIPTION
Increases MAX_IDLE_DURATION to 90s, because games like DL2 with frequent cutscenes longer than 30s end up causing this behaviour noted by Louis:
> dying light 2 has a weird bug with the recorder where it goes for 2 minutes, stops, then starts again after like 30 sec

Confirmed it's not a bug with the recorder itself, crosschecking the inputs.csv + logging outputs, the recordings all terminate at cutscenes because of the idleness tracker and no registered inputs for 30s before the end.

Idk it's pretty straightforward.