### PR TITLE
Fix get_obs_window_encoding function

### DIFF
--- a/crates/owl-recorder/src/window_recorder.rs
+++ b/crates/owl-recorder/src/window_recorder.rs
@@ -331,7 +331,10 @@ fn get_obs_window_encoding(hwnd: HWND, game_exe: &str) -> String {
             }
         }
     }
-
+    
+    // Sanitize colons in title (OBS uses ':' as a separator)
+    let title = title.replace(':', "-");
+    
     // Get window class
     let mut class_buf = [0u16; 256];
     let class_len = unsafe { GetClassNameW(hwnd, &mut class_buf) };


### PR DESCRIPTION
get_obs_window_encoding returns a string separated by colons as follows "{title}:{class}:{game_exe}". 
However, the title itself could contain colons and return an unexpected string and breaking the recorder. 
This change replaces colons in the title with dashes as OBS does not care about the game title to record, just the game executable