### PR TITLE
Reuse OBS state

### DIFF
--- a/src/output_types.rs
+++ b/src/output_types.rs
@@ -92,8 +92,6 @@ pub enum InputEventType {
     VideoEnd,
     /// HOOK_START
     HookStart,
-    /// HOOK_END
-    HookEnd,
     /// MOUSE_MOVE: [dx : int, dy : int]
     MouseMove { dx: i32, dy: i32 },
     /// MOUSE_BUTTON: [button_idx : int, key_down : bool]
@@ -125,7 +123,6 @@ impl InputEventType {
             InputEventType::VideoStart => "VIDEO_START",
             InputEventType::VideoEnd => "VIDEO_END",
             InputEventType::HookStart => "HOOK_START",
-            InputEventType::HookEnd => "HOOK_END",
             InputEventType::MouseMove { .. } => "MOUSE_MOVE",
             InputEventType::MouseButton { .. } => "MOUSE_BUTTON",
             InputEventType::Scroll { .. } => "SCROLL",
@@ -150,7 +147,6 @@ impl InputEventType {
             InputEventType::VideoStart => json!([]),
             InputEventType::VideoEnd => json!([]),
             InputEventType::HookStart => json!([]),
-            InputEventType::HookEnd => json!([]),
             InputEventType::MouseMove { dx, dy } => json!([dx, dy]),
             InputEventType::MouseButton { button, pressed } => json!([button, pressed]),
             InputEventType::Scroll { amount } => json!([amount]),

--- a/src/record/obs_embedded_recorder.rs
+++ b/src/record/obs_embedded_recorder.rs
@@ -377,10 +377,6 @@ impl RecorderState {
                 .signal_manager()
                 .on_hooked()
                 .context("failed to register source on_hooked signal")?;
-            let mut unhook_signal_rx = source
-                .signal_manager()
-                .on_unhooked()
-                .context("failed to register source on_unhooked signal")?;
 
             let last_game_exe = self.last_game_exe.clone();
             let game_exe = request.game_exe.clone();
@@ -415,12 +411,6 @@ impl RecorderState {
                                     tracing::info!("Game hooked at {}s", initial_time.elapsed().as_secs_f64());
                                     let _ = event_stream.send(InputEventType::HookStart);
                                     was_hooked.store(true, Ordering::Relaxed);
-                                }
-                            }
-                            r = unhook_signal_rx.recv() => {
-                                if r.is_ok() {
-                                    tracing::info!("Game unhooked at {}s", initial_time.elapsed().as_secs_f64());
-                                    let _ = event_stream.send(InputEventType::HookEnd);
                                 }
                             }
                             _ = &mut shutdown_rx => {


### PR DESCRIPTION
Based on #101.

Attempts to reuse as much OBS state as possible. Doesn't actually work right now, because it never hooks the game / gets any footage from the game on the second recording; guessing we can't actually reuse the output? Not sure.

I'd like to preserve the encoders (per encoder type) and carry them across when rebuilding the output, but that will depend on https://github.com/joshprk/libobs-rs/issues/38 