### PR TITLE
Fixes black overlay background instead of transparent

### DIFF
--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -185,8 +185,8 @@ impl EguiOverlay for OverlayApp {
             update_overlay_position_based_on_location(&mut glfw_backend.window, curr_location);
         }
         let frame = Frame {
-            fill: Color32::BLACK,      // Solid black background (opacity controlled by window)
-            stroke: Stroke::NONE,      // No border
+            fill: Color32::BLACK, // Solid black background (opacity controlled by window)
+            stroke: Stroke::NONE, // No border
             corner_radius: 0.0.into(), // No rounded corners
             shadow: Default::default(), // Default shadow settings
             inner_margin: Margin::same(8), // Inner padding
@@ -284,7 +284,7 @@ impl EguiOverlay for OverlayApp {
             let content_size = window_rect.size();
 
             // Only resize if content size has changed to avoid unnecessary updates
-            if self.last_content_size.map_or(true, |last| {
+            if self.last_content_size.is_none_or(|last| {
                 (last.x - content_size.x).abs() > 0.5 || (last.y - content_size.y).abs() > 0.5
             }) {
                 self.last_content_size = Some(content_size);


### PR DESCRIPTION
somehow managed to repro #158 in the process of vibe coding the refactor. pushed up here so we can take a closer look.

~~This should eventually be a complete refactor of the overlay to use only winit + wgpu.~~
winit + wgpu overlay refactor was too bloated, and ran into too many issues with existing bugs in being unable to detect correct adapters and defaulting to Opaque rendering every time, which seems to be the core issue causing black backgrounds of the overlay in some users. Either their system's drivers don't support pre/post-multiplied alpha rendering, or there is a bug in informing the software that such an option is available, and it defaults to Opaque.

Instead we fix #158 by shrinking the window size to be exactly the size of the overlay elements, and set the opacity of the entire window directly instead of through the egui elements. This means that even if the renderer defaults to Opaque and renders all UI elements without alpha values, the overall window opacity will still take effect, and the black background is exactly the size of the normal frame black background so it won't show up as an ugly ass bar.